### PR TITLE
Add href= attributes to pagination links

### DIFF
--- a/app/pagination/controllers/main_controller.rb
+++ b/app/pagination/controllers/main_controller.rb
@@ -79,26 +79,43 @@ module Pagination
     end
 
     def next_page
-      new_page = current_page + 1
-      if new_page <= total_pages
-        set_page(new_page)
-      end
+      return 2 unless current_page
+      return nil if last_page
+      current_page + 1
     end
 
     def previous_page
-      new_page = current_page - 1
-      if new_page >= 1
-        set_page(new_page)
-      end
+      return nil unless current_page
+      return nil if first_page
+      current_page - 1
+    end
+
+    def go_next_page
+      set_page(next_page) if next_page
+    end
+
+    def go_previous_page
+      set_page(previous_page) if previous_page
     end
 
     def set_page(page_number)
+      return unless left_click?
+      prevent_default
       page_number = page_number.to_i
       if attrs.respond_to?(:page=)
         attrs.page = page_number
       else
         params._page = page_number
       end
+    end
+
+    def left_click?
+      `event.which` == 1
+    end
+
+    def prevent_default
+      `event.preventDefault();`
+      `event.stopPropagation();`
     end
   end
 end

--- a/app/pagination/views/main/index.html
+++ b/app/pagination/views/main/index.html
@@ -1,18 +1,18 @@
 <:Body>
   <ul class="pagination">
     <li class="{{ if first_page }}disabled{{ end }}">
-      <a e-click="previous_page">&laquo;</a>
+      <a e-click="go_previous_page" href="{{ previous_page }}">&laquo;</a>
     </li>
     {{ page_numbers.each do |page_number| }}
       {{ if page_number.nil? }}
         <li><a>...</a></li>
       {{ else }}
         <li class="{{ if current_page == page_number }}active{{ end }}">
-          <a e-click="set_page(page_number)">{{ page_number }}</a>
+          <a e-click="set_page(page_number)" href="{{ page_number }}">{{ page_number }}</a>
         </li>
       {{ end }}
     {{ end }}
     <li class="{{ if last_page }}disabled{{ end }}">
-      <a e-click="next_page">&raquo;</a>
+      <a e-click="go_next_page" href="{{ next_page }}">&raquo;</a>
     </li>
   </ul>


### PR DESCRIPTION
I tried adding href attributes to the pagination links in order to enable "Open In New Tab/Window" and middle mouse button behaviors.

It is a Work In Progress.  I don't know how to create a URL from parameters.

I was looking at Volt::Routes#params_to_url(test_params) 
https://github.com/voltrb/volt/blob/ca715efed64412e6db94b9ddbe36505524dc1e7d/lib/volt/router/routes.rb#L76

This _currently_ only works at the site root with page numbers in the path like
/
/1
/2
