### PR TITLE
Use events to change pages; make '...' buttons work

### DIFF
--- a/app/pagination/controllers/main_controller.rb
+++ b/app/pagination/controllers/main_controller.rb
@@ -22,13 +22,21 @@ module Pagination
       return start_pos, end_pos
     end
 
-    def page_numbers
+    def page_numbers i=nil
       total_pages.then do |total|
 
         cpage = current_page()
 
-        start_pos, end_pos = middle_window(cpage, total)
-        middle_window = (start_pos..end_pos).to_a
+        if i == 0
+          start_pos, end_pos = middle_window(cpage-2, total)
+          middle_window = (start_pos..end_pos).to_a
+        elsif i == 1
+          start_pos, end_pos = middle_window(cpage+2, total)
+          middle_window = (start_pos..end_pos).to_a
+        else
+          start_pos, end_pos = middle_window(cpage, total)
+          middle_window = (start_pos..end_pos).to_a
+        end
 
         if outer_window == 0
           pages = middle_window
@@ -44,11 +52,16 @@ module Pagination
           pages = start_window
           pages << nil unless start_outer_pos == (middle_window[0] - 1)
           pages += middle_window
-          pages << nil unless end_outer_pos == middle_window[-1] + 1
+          pages << 0 unless end_outer_pos == middle_window[-1] + 1
           pages += end_window
         end
+        page._pages = pages
+      end
+    end
 
-        pages
+    def expand_pages x
+      page_numbers(x).then do |pages|
+        page._pages = pages
       end
     end
 

--- a/app/pagination/controllers/main_controller.rb
+++ b/app/pagination/controllers/main_controller.rb
@@ -96,32 +96,28 @@ module Pagination
       current_page == 1
     end
 
-    def next_page_url
+    def goto_next_page
       total_pages.then do |total_pages|
         new_page = current_page + 1
         if new_page > total_pages
           next ''
         end
 
-        url_for_page(new_page)
+        params.send(:"_#{page_param_name}=", new_page)
       end
     end
 
-    def previous_page_url
+    def goto_previous_page
       new_page = current_page - 1
       if new_page < 1
         return ''
       end
 
-      return url_for_page(new_page)
+      params.send(:"_#{page_param_name}=", new_page)
     end
 
     def page_param_name
       attrs.page_param_name || :page
-    end
-
-    def url_for_page(page_number)
-      url_with({page_param_name => page_number})
     end
 
     def set_page(page_number)

--- a/app/pagination/controllers/main_controller.rb
+++ b/app/pagination/controllers/main_controller.rb
@@ -4,10 +4,10 @@ module Pagination
     def page_numbers(i=nil)
       total_pages.then do |total|
         if i == 0
-          start_pos, end_pos = middle_window(page._pages[2] - 3, total)
+          start_pos, end_pos = middle_window(controller._pages[2] - 3, total)
           middle_window = (start_pos..end_pos).to_a
         elsif i == 1
-          start_pos, end_pos = middle_window(page._pages[2] + window + 2, total)
+          start_pos, end_pos = middle_window(controller._pages[2] + window + 2, total)
           middle_window = (start_pos..end_pos).to_a
         else
           start_pos, end_pos = middle_window(current_page, total)
@@ -31,14 +31,18 @@ module Pagination
           pages << 0 unless end_outer_pos == middle_window[-1] + 1
           pages += end_window
         end
-        page._pages = pages
+        controller._pages = pages
       end
     end
 
     def expand_pages x
       page_numbers(x).then do |pages|
-        page._pages = pages
+        controller._pages = pages
       end
+    end
+
+    def certain_page
+      controller._pages
     end
 
     def window

--- a/app/pagination/views/main/index.html
+++ b/app/pagination/views/main/index.html
@@ -2,7 +2,7 @@
   <li class="{{ if first_page }}disabled{{ end }}">
     <a e-click="goto_previous_page">&laquo;</a>
   </li>
-  {{ page._pages.each do |page_number| }}
+  {{ certain_page.each do |page_number| }}
     {{ if page_number.nil? }}<!-- first ... -->
       <li><a e-click="expand_pages(0)">...</a></li>
     {{ elsif page_number == 0 }}<!-- last ... -->

--- a/app/pagination/views/main/index.html
+++ b/app/pagination/views/main/index.html
@@ -1,6 +1,6 @@
 <ul class="pagination">
   <li class="{{ if first_page }}disabled{{ end }}">
-    <a href="{{ previous_page_url }}">&laquo;</a>
+    <a e-click="goto_previous_page">&laquo;</a>
   </li>
   {{ page._pages.each do |page_number| }}
     {{ if page_number.nil? }}<!-- first ... -->
@@ -9,11 +9,11 @@
       <li><a e-click="expand_pages(1)">...</a></li>
     {{ else }}
       <li class="{{ if current_page == page_number }}active{{ end }}">
-        <a href="{{ url_for_page(page_number) }}">{{ page_number }}</a>
+        <a e-click="set_page(page_number)">{{ page_number }}</a>
       </li>
     {{ end }}
   {{ end }}
   <li class="{{ if last_page }}disabled{{ end }}">
-    <a href="{{ next_page_url }}">&raquo;</a>
+    <a e-click="goto_next_page">&raquo;</a>
   </li>
 </ul>

--- a/app/pagination/views/main/index.html
+++ b/app/pagination/views/main/index.html
@@ -2,9 +2,11 @@
   <li class="{{ if first_page }}disabled{{ end }}">
     <a href="{{ previous_page_url }}">&laquo;</a>
   </li>
-  {{ page_numbers.each do |page_number| }}
-    {{ if page_number.nil? }}
-      <li><a>...</a></li>
+  {{ page._pages.each do |page_number| }}
+    {{ if page_number.nil? }}<!-- first ... -->
+      <li><a e-click="expand_pages(0)">...</a></li>
+    {{ elsif page_number == 0 }}<!-- last ... -->
+      <li><a e-click="expand_pages(1)">...</a></li>
     {{ else }}
       <li class="{{ if current_page == page_number }}active{{ end }}">
         <a href="{{ url_for_page(page_number) }}">{{ page_number }}</a>


### PR DESCRIPTION
(1) Adds ability to click '...' buttons and see more pages
(2) Uses events instead of links to change the page param in order to eliminate a bug that would clobber other params that had been set since the page load.

Updated to current master; ready to merge. Sorry for the messy commit history.
